### PR TITLE
[codex] Add AI-assisted TipEasy experience

### DIFF
--- a/SwiftUI-TipEasy/AppIntents/TipEasyIntents.swift
+++ b/SwiftUI-TipEasy/AppIntents/TipEasyIntents.swift
@@ -1,0 +1,155 @@
+import AppIntents
+import Foundation
+import SwiftData
+
+enum TipEasyDestination: String, AppEnum {
+    case calculator
+    case scanner
+    case history
+    case settings
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Tip Easy Destination")
+
+    static var caseDisplayRepresentations: [TipEasyDestination: DisplayRepresentation] = [
+        .calculator: "Calculator",
+        .scanner: "Receipt Scanner",
+        .history: "History",
+        .settings: "Settings"
+    ]
+}
+
+struct CalculateTipIntent: AppIntent {
+    static var title: LocalizedStringResource = "Calculate Tip"
+    static var description = IntentDescription("Calculate a tip and total without opening Tip Easy.")
+
+    @Parameter(title: "Bill Amount")
+    var billAmount: Double
+
+    @Parameter(title: "Tip Percent")
+    var tipPercent: Double
+
+    init() {
+        billAmount = 50
+        tipPercent = 20
+    }
+
+    init(billAmount: Double, tipPercent: Double) {
+        self.billAmount = billAmount
+        self.tipPercent = tipPercent
+    }
+
+    func perform() async throws -> some IntentResult {
+        let tip = billAmount * tipPercent / 100
+        let total = billAmount + tip
+        let currencyCode = Locale.current.currency?.identifier ?? "USD"
+
+        return .result(dialog: """
+        \(Int(tipPercent))% tip is \(tip.formatted(.currency(code: currencyCode))). Total is \(total.formatted(.currency(code: currencyCode))).
+        """)
+    }
+}
+
+struct SaveTipIntent: AppIntent {
+    static var title: LocalizedStringResource = "Save Tip"
+    static var description = IntentDescription("Save a tip calculation to Tip Easy history.")
+
+    @Parameter(title: "Bill Amount")
+    var billAmount: Double
+
+    @Parameter(title: "Tip Percent")
+    var tipPercent: Double
+
+    @Parameter(title: "Restaurant")
+    var restaurantName: String
+
+    init() {
+        billAmount = 50
+        tipPercent = 20
+        restaurantName = ""
+    }
+
+    func perform() async throws -> some IntentResult {
+        let tip = billAmount * tipPercent / 100
+        let total = billAmount + tip
+        let container = try ModelContainer(for: TipPreset.self, TipTransaction.self)
+        let context = ModelContext(container)
+
+        context.insert(TipTransaction(
+            restaurantName: restaurantName,
+            billAmount: billAmount,
+            tipPercentage: tipPercent / 100,
+            tipAmount: tip,
+            totalAmount: total
+        ))
+        try context.save()
+
+        return .result(dialog: "Saved to Tip Easy history.")
+    }
+}
+
+struct OpenTipEasyIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Tip Easy"
+    static var description = IntentDescription("Open Tip Easy to a specific area.")
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Destination")
+    var destination: TipEasyDestination
+
+    init() {
+        destination = .calculator
+    }
+
+    init(destination: TipEasyDestination) {
+        self.destination = destination
+    }
+
+    func perform() async throws -> some IntentResult {
+        UserDefaults.standard.set(destination.rawValue, forKey: "pendingTipEasyDestination")
+        UserDefaults.standard.set(destination == .scanner, forKey: "pendingOpenScanner")
+        return .result()
+    }
+}
+
+struct TipEasyShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: CalculateTipIntent(),
+            phrases: [
+                "Calculate a tip with \(.applicationName)",
+                "Calculate \(.applicationName) tip"
+            ],
+            shortTitle: "Calculate Tip",
+            systemImageName: "percent"
+        )
+
+        AppShortcut(
+            intent: SaveTipIntent(),
+            phrases: [
+                "Save a tip with \(.applicationName)",
+                "Add tip to \(.applicationName)"
+            ],
+            shortTitle: "Save Tip",
+            systemImageName: "tray.and.arrow.down"
+        )
+
+        AppShortcut(
+            intent: OpenTipEasyIntent(destination: .scanner),
+            phrases: [
+                "Scan a receipt with \(.applicationName)",
+                "Open \(.applicationName) scanner"
+            ],
+            shortTitle: "Scan Receipt",
+            systemImageName: "camera.viewfinder"
+        )
+
+        AppShortcut(
+            intent: OpenTipEasyIntent(destination: .history),
+            phrases: [
+                "Show \(.applicationName) history",
+                "Open my \(.applicationName) tips"
+            ],
+            shortTitle: "Tip History",
+            systemImageName: "clock.arrow.circlepath"
+        )
+    }
+}

--- a/SwiftUI-TipEasy/Info.plist
+++ b/SwiftUI-TipEasy/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3911596373332918~1081182764</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Tip Easy uses the camera to read receipt totals and show tip suggestions.</string>
     <key>SKAdNetworkItems</key>
     <array>
       <dict>

--- a/SwiftUI-TipEasy/Models/ReceiptScanResult.swift
+++ b/SwiftUI-TipEasy/Models/ReceiptScanResult.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct ReceiptScanResult: Equatable {
+    var merchantName: String
+    var subtotal: Double?
+    var tax: Double?
+    var serviceCharge: Double?
+    var includedGratuity: Double?
+    var total: Double?
+    var rawText: String
+    var usedAppleIntelligence: Bool
+
+    static let empty = ReceiptScanResult(
+        merchantName: "",
+        subtotal: nil,
+        tax: nil,
+        serviceCharge: nil,
+        includedGratuity: nil,
+        total: nil,
+        rawText: "",
+        usedAppleIntelligence: false
+    )
+
+    var hasIncludedService: Bool {
+        (serviceCharge ?? 0) > 0 || (includedGratuity ?? 0) > 0
+    }
+}

--- a/SwiftUI-TipEasy/Models/TipTransaction.swift
+++ b/SwiftUI-TipEasy/Models/TipTransaction.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftData
+
+@Model
+final class TipTransaction: Identifiable {
+    var id: UUID = UUID()
+    var date: Date
+    var restaurantName: String
+    var billAmount: Double
+    var tipPercentage: Double
+    var tipAmount: Double
+    var totalAmount: Double
+
+    init(
+        date: Date = .now,
+        restaurantName: String = "",
+        billAmount: Double,
+        tipPercentage: Double,
+        tipAmount: Double,
+        totalAmount: Double
+    ) {
+        self.date = date
+        self.restaurantName = restaurantName
+        self.billAmount = billAmount
+        self.tipPercentage = tipPercentage
+        self.tipAmount = tipAmount
+        self.totalAmount = totalAmount
+    }
+}

--- a/SwiftUI-TipEasy/Services/ReceiptIntelligenceService.swift
+++ b/SwiftUI-TipEasy/Services/ReceiptIntelligenceService.swift
@@ -1,0 +1,160 @@
+import Foundation
+import FoundationModels
+
+enum ReceiptIntelligenceService {
+    static func analyzeReceiptText(_ text: String) async -> ReceiptScanResult {
+        var localResult = ReceiptTextParser.analyze(text)
+
+        guard #available(iOS 26.0, *), SystemLanguageModel.default.isAvailable else {
+            return localResult
+        }
+
+        do {
+            let session = LanguageModelSession(
+                instructions: """
+                You extract structured receipt data for a tip calculator. Return JSON only.
+                Keys: merchantName, subtotal, tax, serviceCharge, includedGratuity, total.
+                Use numbers for amounts. Use null when a field is absent. Do not guess beyond the receipt text.
+                """
+            )
+
+            let response = try await session.respond(to: """
+            Receipt OCR:
+            \(text)
+            """)
+
+            if let modelResult = parseModelJSON(response.content, rawText: text) {
+                localResult = merge(localResult, with: modelResult)
+                localResult.usedAppleIntelligence = true
+            }
+        } catch {
+            return localResult
+        }
+
+        return localResult
+    }
+
+    private static func parseModelJSON(_ json: String, rawText: String) -> ReceiptScanResult? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return ReceiptScanResult(
+            merchantName: object["merchantName"] as? String ?? "",
+            subtotal: number(for: "subtotal", in: object),
+            tax: number(for: "tax", in: object),
+            serviceCharge: number(for: "serviceCharge", in: object),
+            includedGratuity: number(for: "includedGratuity", in: object),
+            total: number(for: "total", in: object),
+            rawText: rawText,
+            usedAppleIntelligence: true
+        )
+    }
+
+    private static func number(for key: String, in object: [String: Any]) -> Double? {
+        if let value = object[key] as? Double {
+            return value
+        }
+
+        if let value = object[key] as? Int {
+            return Double(value)
+        }
+
+        if let value = object[key] as? String {
+            return ReceiptTextParser.parseAmount(value)
+        }
+
+        return nil
+    }
+
+    private static func merge(_ fallback: ReceiptScanResult, with model: ReceiptScanResult) -> ReceiptScanResult {
+        ReceiptScanResult(
+            merchantName: model.merchantName.isEmpty ? fallback.merchantName : model.merchantName,
+            subtotal: model.subtotal ?? fallback.subtotal,
+            tax: model.tax ?? fallback.tax,
+            serviceCharge: model.serviceCharge ?? fallback.serviceCharge,
+            includedGratuity: model.includedGratuity ?? fallback.includedGratuity,
+            total: model.total ?? fallback.total,
+            rawText: fallback.rawText,
+            usedAppleIntelligence: true
+        )
+    }
+}
+
+enum ReceiptTextParser {
+    static func analyze(_ text: String) -> ReceiptScanResult {
+        let lines = text
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let subtotal = labeledAmount(in: lines, labels: ["subtotal", "sub total"])
+        let tax = labeledAmount(in: lines, labels: ["tax", "sales tax"])
+        let service = labeledAmount(in: lines, labels: ["service", "service charge", "surcharge"])
+        let gratuity = labeledAmount(in: lines, labels: ["gratuity", "included tip", "auto gratuity", "tip included"])
+        let total = labeledAmount(in: lines, labels: ["total", "amount due", "balance due", "paid"])
+            ?? amounts(in: text).max()
+
+        return ReceiptScanResult(
+            merchantName: merchantName(from: lines),
+            subtotal: subtotal,
+            tax: tax,
+            serviceCharge: service,
+            includedGratuity: gratuity,
+            total: total,
+            rawText: text,
+            usedAppleIntelligence: false
+        )
+    }
+
+    static func amounts(in text: String) -> [Double] {
+        let pattern = #"(?<!\d)(?:[$€£]\s*)?(\d{1,4}(?:[,.]\d{3})*(?:[,.]\d{2})|\d{1,4}[,.]\d{2})(?!\d)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard let amountRange = Range(match.range(at: 1), in: text) else { return nil }
+            return parseAmount(String(text[amountRange]))
+        }
+        .filter { $0 > 0 }
+    }
+
+    static func parseAmount(_ rawValue: String) -> Double? {
+        var value = rawValue.replacingOccurrences(of: " ", with: "")
+
+        if value.contains(","), value.contains(".") {
+            value = value.replacingOccurrences(of: ",", with: "")
+        } else {
+            value = value.replacingOccurrences(of: ",", with: ".")
+        }
+
+        return Double(value.filter { "0123456789.".contains($0) })
+    }
+
+    private static func labeledAmount(in lines: [String], labels: [String]) -> Double? {
+        for line in lines.reversed() {
+            let lowercased = line.lowercased()
+            guard labels.contains(where: { lowercased.contains($0) }) else { continue }
+            if let amount = amounts(in: line).last {
+                return amount
+            }
+        }
+
+        return nil
+    }
+
+    private static func merchantName(from lines: [String]) -> String {
+        let ignoredTerms = ["receipt", "invoice", "order", "table", "server", "date", "time", "total", "tax", "subtotal"]
+
+        return lines
+            .prefix(6)
+            .first { line in
+                let lowercased = line.lowercased()
+                return line.count >= 3
+                    && amounts(in: line).isEmpty
+                    && !ignoredTerms.contains(where: { lowercased.contains($0) })
+            } ?? ""
+    }
+}

--- a/SwiftUI-TipEasy/Services/TipIntelligenceService.swift
+++ b/SwiftUI-TipEasy/Services/TipIntelligenceService.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+struct TipInsight: Identifiable, Equatable {
+    enum Kind {
+        case info
+        case warning
+    }
+
+    let id = UUID()
+    let title: String
+    let message: String
+    let kind: Kind
+}
+
+struct HistorySummary {
+    let title: String
+    let message: String
+    let highlights: [String]
+}
+
+enum TipIntelligenceService {
+    static func explanation(
+        bill: Double,
+        tipPercentage: Double,
+        tipAmount: Double,
+        scanResult: ReceiptScanResult?
+    ) -> TipInsight? {
+        guard bill > 0 else { return nil }
+
+        if let scanResult, scanResult.hasIncludedService {
+            let included = (scanResult.serviceCharge ?? 0) + (scanResult.includedGratuity ?? 0)
+            return TipInsight(
+                title: "Service may already be included",
+                message: "The receipt appears to include \(included.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))). Consider whether an extra tip is needed.",
+                kind: .warning
+            )
+        }
+
+        let percentage = Int((tipPercentage * 100).rounded())
+        let message: String
+        if tipPercentage < 0.15 {
+            message = "\(percentage)% is below the common dining range. It can still fit counter service or a bill with an included charge."
+        } else if tipPercentage < 0.20 {
+            message = "\(percentage)% is a standard dining tip. It adds \(tipAmount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))) to this bill."
+        } else {
+            message = "\(percentage)% is a generous option for attentive service. It adds \(tipAmount.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))) to this bill."
+        }
+
+        return TipInsight(title: "Tip context", message: message, kind: .info)
+    }
+
+    static func anomalies(
+        bill: Double,
+        tipPercentage: Double,
+        restaurantName: String,
+        scanResult: ReceiptScanResult?,
+        transactions: [TipTransaction]
+    ) -> [TipInsight] {
+        guard bill > 0 else { return [] }
+
+        var insights: [TipInsight] = []
+        let trimmedName = restaurantName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if let scanResult, scanResult.hasIncludedService {
+            insights.append(TipInsight(
+                title: "Check included charges",
+                message: "This receipt looks like it already includes a service charge or gratuity.",
+                kind: .warning
+            ))
+        }
+
+        if transactions.contains(where: { transaction in
+            Calendar.current.isDate(transaction.date, inSameDayAs: .now)
+                && abs(transaction.billAmount - bill) < 0.01
+                && (trimmedName.isEmpty || transaction.restaurantName.lowercased() == trimmedName)
+        }) {
+            insights.append(TipInsight(
+                title: "Possible duplicate",
+                message: "A similar bill is already saved today.",
+                kind: .warning
+            ))
+        }
+
+        if !transactions.isEmpty {
+            let averageTip = transactions.reduce(0) { $0 + $1.tipPercentage } / Double(transactions.count)
+            if tipPercentage > max(0.30, averageTip + 0.10) {
+                insights.append(TipInsight(
+                    title: "Higher than usual",
+                    message: "This tip is above your usual range of about \(Int(averageTip * 100))%.",
+                    kind: .warning
+                ))
+            }
+        }
+
+        return insights
+    }
+
+    static func summary(for transactions: [TipTransaction], currencyCode: String) -> HistorySummary? {
+        guard !transactions.isEmpty else { return nil }
+
+        let calendar = Calendar.current
+        let thisMonth = transactions.filter { calendar.isDate($0.date, equalTo: .now, toGranularity: .month) }
+        let scope = thisMonth.isEmpty ? transactions : thisMonth
+        let total = scope.reduce(0) { $0 + $1.totalAmount }
+        let averageTip = scope.reduce(0) { $0 + $1.tipPercentage } / Double(scope.count)
+        let weekendCount = scope.filter { date in
+            calendar.isDateInWeekend(date.date)
+        }.count
+
+        let topPlace = Dictionary(grouping: scope.filter { !$0.restaurantName.isEmpty }, by: \.restaurantName)
+            .map { (name: $0.key, total: $0.value.reduce(0) { $0 + $1.totalAmount }) }
+            .max { $0.total < $1.total }?
+            .name
+
+        let title = thisMonth.isEmpty ? "Saved history summary" : "This month"
+        var highlights = [
+            "\(scope.count) saved visit\(scope.count == 1 ? "" : "s")",
+            "Average tip \(Int(averageTip * 100))%",
+            "\(total.formatted(.currency(code: currencyCode))) total"
+        ]
+
+        if weekendCount > 0 {
+            highlights.append("\(weekendCount) weekend visit\(weekendCount == 1 ? "" : "s")")
+        }
+
+        if let topPlace {
+            highlights.append("Top place: \(topPlace)")
+        }
+
+        return HistorySummary(
+            title: title,
+            message: "Tip Easy summarized your local saved dining activity.",
+            highlights: highlights
+        )
+    }
+}
+
+enum HistorySearchService {
+    static func filter(_ transactions: [TipTransaction], query: String) -> [TipTransaction] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return transactions }
+
+        let lowercased = trimmed.lowercased()
+        return transactions.filter { transaction in
+            matchesText(transaction, query: lowercased)
+                || matchesRelativeDate(transaction, query: lowercased)
+                || matchesTipComparison(transaction, query: lowercased)
+                || matchesAmount(transaction, query: lowercased)
+        }
+    }
+
+    private static func matchesText(_ transaction: TipTransaction, query: String) -> Bool {
+        transaction.restaurantName.lowercased().contains(query)
+    }
+
+    private static func matchesRelativeDate(_ transaction: TipTransaction, query: String) -> Bool {
+        let calendar = Calendar.current
+
+        if query.contains("this month") {
+            return calendar.isDate(transaction.date, equalTo: .now, toGranularity: .month)
+        }
+
+        if query.contains("last month"),
+           let lastMonth = calendar.date(byAdding: .month, value: -1, to: .now)
+        {
+            return calendar.isDate(transaction.date, equalTo: lastMonth, toGranularity: .month)
+        }
+
+        if query.contains("this year") || query.contains("ytd") {
+            return calendar.isDate(transaction.date, equalTo: .now, toGranularity: .year)
+        }
+
+        if query.contains("last year"),
+           let lastYear = calendar.date(byAdding: .year, value: -1, to: .now)
+        {
+            return calendar.isDate(transaction.date, equalTo: lastYear, toGranularity: .year)
+        }
+
+        return false
+    }
+
+    private static func matchesTipComparison(_ transaction: TipTransaction, query: String) -> Bool {
+        guard let percent = firstNumber(in: query) else { return false }
+        let fraction = percent / 100
+
+        if query.contains("over") || query.contains("above") || query.contains(">") {
+            return transaction.tipPercentage > fraction
+        }
+
+        if query.contains("under") || query.contains("below") || query.contains("<") {
+            return transaction.tipPercentage < fraction
+        }
+
+        return false
+    }
+
+    private static func matchesAmount(_ transaction: TipTransaction, query: String) -> Bool {
+        guard query.contains("$") || query.contains("spent") || query.contains("total"),
+              let amount = firstNumber(in: query)
+        else {
+            return false
+        }
+
+        if query.contains("over") || query.contains("above") || query.contains(">") {
+            return transaction.totalAmount > amount
+        }
+
+        if query.contains("under") || query.contains("below") || query.contains("<") {
+            return transaction.totalAmount < amount
+        }
+
+        return abs(transaction.totalAmount - amount) < 1
+    }
+
+    private static func firstNumber(in text: String) -> Double? {
+        let pattern = #"(\d+(?:\.\d+)?)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..<text.endIndex, in: text)),
+              let range = Range(match.range(at: 1), in: text)
+        else {
+            return nil
+        }
+
+        return Double(text[range])
+    }
+}

--- a/SwiftUI-TipEasy/SwiftUI_TipEasyApp.swift
+++ b/SwiftUI-TipEasy/SwiftUI_TipEasyApp.swift
@@ -26,7 +26,7 @@ struct TipEasyApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .modelContainer(for: [TipPreset.self])
+                .modelContainer(for: [TipPreset.self, TipTransaction.self])
         }
     }
 }

--- a/SwiftUI-TipEasy/Views/AppPalette.swift
+++ b/SwiftUI-TipEasy/Views/AppPalette.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+enum AppAppearance: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system:
+            "System"
+        case .light:
+            "Light"
+        case .dark:
+            "Dark"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .system:
+            "iphone"
+        case .light:
+            "sun.max"
+        case .dark:
+            "moon"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system:
+            nil
+        case .light:
+            .light
+        case .dark:
+            .dark
+        }
+    }
+}
+
+enum AppTheme: String, CaseIterable, Identifiable {
+    case harvest
+    case garden
+    case berry
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .harvest:
+            "Harvest"
+        case .garden:
+            "Garden"
+        case .berry:
+            "Berry"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .harvest:
+            "Tomato, sage, and gold"
+        case .garden:
+            "Citrus, herb, and clay"
+        case .berry:
+            "Plum, rose, and apricot"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .harvest:
+            "fork.knife.circle"
+        case .garden:
+            "leaf.circle"
+        case .berry:
+            "sparkles"
+        }
+    }
+
+    var palette: ThemePalette {
+        switch self {
+        case .harvest:
+            ThemePalette(
+                accent: ThemePalette.dynamic(light: RGB(0.88, 0.27, 0.20), dark: RGB(1.00, 0.48, 0.38)),
+                accentDeep: ThemePalette.dynamic(light: RGB(0.67, 0.20, 0.13), dark: RGB(1.00, 0.66, 0.48)),
+                secondaryAccent: ThemePalette.dynamic(light: RGB(0.45, 0.58, 0.40), dark: RGB(0.66, 0.78, 0.55)),
+                highlight: ThemePalette.dynamic(light: RGB(0.93, 0.64, 0.21), dark: RGB(1.00, 0.76, 0.32)),
+                backgroundTop: ThemePalette.dynamic(light: RGB(1.00, 0.96, 0.89), dark: RGB(0.13, 0.10, 0.08)),
+                backgroundMid: ThemePalette.dynamic(light: RGB(1.00, 0.86, 0.81, 0.62), dark: RGB(0.30, 0.13, 0.10, 0.62)),
+                backgroundBottom: ThemePalette.dynamic(light: RGB(0.89, 0.95, 0.86), dark: RGB(0.08, 0.14, 0.11)),
+                card: ThemePalette.dynamic(light: RGB(1.00, 0.93, 0.84, 0.70), dark: RGB(0.20, 0.17, 0.14, 0.72)),
+                field: ThemePalette.dynamic(light: RGB(0.94, 0.98, 0.90, 0.72), dark: RGB(0.17, 0.22, 0.18, 0.76)),
+                tile: ThemePalette.dynamic(light: RGB(0.98, 0.88, 0.74, 0.82), dark: RGB(0.24, 0.20, 0.16, 0.82)),
+                selectedTile: ThemePalette.dynamic(light: RGB(1.00, 0.76, 0.63, 0.86), dark: RGB(0.39, 0.18, 0.14, 0.88))
+            )
+        case .garden:
+            ThemePalette(
+                accent: ThemePalette.dynamic(light: RGB(0.21, 0.56, 0.40), dark: RGB(0.44, 0.83, 0.62)),
+                accentDeep: ThemePalette.dynamic(light: RGB(0.17, 0.38, 0.29), dark: RGB(0.70, 0.95, 0.75)),
+                secondaryAccent: ThemePalette.dynamic(light: RGB(0.82, 0.51, 0.22), dark: RGB(0.94, 0.64, 0.34)),
+                highlight: ThemePalette.dynamic(light: RGB(0.95, 0.77, 0.24), dark: RGB(1.00, 0.86, 0.36)),
+                backgroundTop: ThemePalette.dynamic(light: RGB(0.94, 0.98, 0.84), dark: RGB(0.07, 0.14, 0.11)),
+                backgroundMid: ThemePalette.dynamic(light: RGB(1.00, 0.91, 0.67, 0.55), dark: RGB(0.21, 0.27, 0.13, 0.58)),
+                backgroundBottom: ThemePalette.dynamic(light: RGB(0.86, 0.94, 0.89), dark: RGB(0.13, 0.11, 0.08)),
+                card: ThemePalette.dynamic(light: RGB(0.97, 0.93, 0.77, 0.70), dark: RGB(0.15, 0.22, 0.18, 0.74)),
+                field: ThemePalette.dynamic(light: RGB(0.89, 0.97, 0.84, 0.74), dark: RGB(0.12, 0.25, 0.19, 0.76)),
+                tile: ThemePalette.dynamic(light: RGB(0.96, 0.87, 0.62, 0.84), dark: RGB(0.22, 0.25, 0.16, 0.84)),
+                selectedTile: ThemePalette.dynamic(light: RGB(0.72, 0.91, 0.63, 0.86), dark: RGB(0.12, 0.36, 0.25, 0.90))
+            )
+        case .berry:
+            ThemePalette(
+                accent: ThemePalette.dynamic(light: RGB(0.62, 0.25, 0.56), dark: RGB(0.92, 0.55, 0.85)),
+                accentDeep: ThemePalette.dynamic(light: RGB(0.36, 0.16, 0.42), dark: RGB(0.82, 0.64, 1.00)),
+                secondaryAccent: ThemePalette.dynamic(light: RGB(0.88, 0.39, 0.43), dark: RGB(1.00, 0.57, 0.62)),
+                highlight: ThemePalette.dynamic(light: RGB(0.95, 0.62, 0.30), dark: RGB(1.00, 0.75, 0.42)),
+                backgroundTop: ThemePalette.dynamic(light: RGB(0.99, 0.91, 0.95), dark: RGB(0.12, 0.08, 0.16)),
+                backgroundMid: ThemePalette.dynamic(light: RGB(1.00, 0.81, 0.72, 0.58), dark: RGB(0.28, 0.11, 0.24, 0.60)),
+                backgroundBottom: ThemePalette.dynamic(light: RGB(0.93, 0.89, 0.99), dark: RGB(0.16, 0.10, 0.10)),
+                card: ThemePalette.dynamic(light: RGB(0.99, 0.88, 0.91, 0.72), dark: RGB(0.20, 0.14, 0.23, 0.76)),
+                field: ThemePalette.dynamic(light: RGB(0.98, 0.91, 0.83, 0.75), dark: RGB(0.26, 0.17, 0.22, 0.76)),
+                tile: ThemePalette.dynamic(light: RGB(0.98, 0.82, 0.76, 0.84), dark: RGB(0.27, 0.17, 0.24, 0.84)),
+                selectedTile: ThemePalette.dynamic(light: RGB(0.90, 0.72, 0.95, 0.86), dark: RGB(0.39, 0.18, 0.42, 0.90))
+            )
+        }
+    }
+}
+
+struct RGB {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+
+    init(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat = 1) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.alpha = alpha
+    }
+}
+
+struct ThemePalette {
+    let accent: Color
+    let accentDeep: Color
+    let secondaryAccent: Color
+    let highlight: Color
+    let backgroundTop: Color
+    let backgroundMid: Color
+    let backgroundBottom: Color
+    let card: Color
+    let field: Color
+    let tile: Color
+    let selectedTile: Color
+
+    var stroke: Color {
+        secondaryAccent.opacity(0.24)
+    }
+
+    var glassTint: Color {
+        highlight.opacity(0.07)
+    }
+
+    static func dynamic(light: RGB, dark: RGB) -> Color {
+        Color(uiColor: UIColor { traits in
+            let color = traits.userInterfaceStyle == .dark ? dark : light
+            return UIColor(red: color.red, green: color.green, blue: color.blue, alpha: color.alpha)
+        })
+    }
+}
+
+private struct AppThemeKey: EnvironmentKey {
+    static let defaultValue: AppTheme = .harvest
+}
+
+extension EnvironmentValues {
+    var appTheme: AppTheme {
+        get { self[AppThemeKey.self] }
+        set { self[AppThemeKey.self] = newValue }
+    }
+
+    var appPalette: ThemePalette {
+        appTheme.palette
+    }
+}

--- a/SwiftUI-TipEasy/Views/ContentView.swift
+++ b/SwiftUI-TipEasy/Views/ContentView.swift
@@ -3,23 +3,98 @@ import GoogleMobileAds
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.scenePhase) private var scenePhase
+    @AppStorage("selectedAppTheme") private var selectedThemeRawValue = AppTheme.harvest.rawValue
+    @AppStorage("appAppearance") private var appAppearanceRawValue = AppAppearance.system.rawValue
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @State private var selectedTab: AppTab = .calculator
+
+    private var selectedTheme: AppTheme {
+        AppTheme(rawValue: selectedThemeRawValue) ?? .harvest
+    }
+
+    private var appAppearance: AppAppearance {
+        AppAppearance(rawValue: appAppearanceRawValue) ?? .system
+    }
+
     var body: some View {
-        NavigationStack {
-            TipCalculatorView()
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        NavigationLink {
-                            TipPresetSettingsView()
-                        } label: {
-                            Image(systemName: "gearshape.fill")
-                                .symbolRenderingMode(.hierarchical)
-                        }
-                        .glassEffect(.regular.interactive())
-                    }
-                }
-                .toolbarBackground(.visible, for: .navigationBar)
+        TabView(selection: $selectedTab) {
+            NavigationStack {
+                TipCalculatorView()
+            }
+            .tabItem {
+                Label("Calculator", systemImage: "percent")
+            }
+            .tag(AppTab.calculator)
+
+            NavigationStack {
+                TipHistoryView()
+            }
+            .tabItem {
+                Label("History", systemImage: "clock.arrow.circlepath")
+            }
+            .tag(AppTab.history)
+
+            NavigationStack {
+                TipPresetSettingsView()
+            }
+            .tabItem {
+                Label("Settings", systemImage: "slider.horizontal.3")
+            }
+            .tag(AppTab.settings)
+        }
+        .environment(\.appTheme, selectedTheme)
+        .preferredColorScheme(appAppearance.colorScheme)
+        .tint(selectedTheme.palette.accent)
+        .fullScreenCover(isPresented: onboardingPresentation) {
+            OnboardingView(hasCompletedOnboarding: $hasCompletedOnboarding)
+                .environment(\.appTheme, selectedTheme)
+                .preferredColorScheme(appAppearance.colorScheme)
+        }
+        .onAppear {
+            routePendingDestination()
+        }
+        .onChange(of: scenePhase) { _, newValue in
+            if newValue == .active {
+                routePendingDestination()
+            }
         }
     }
+
+    private var onboardingPresentation: Binding<Bool> {
+        Binding {
+            !hasCompletedOnboarding
+        } set: { isPresented in
+            if !isPresented {
+                hasCompletedOnboarding = true
+            }
+        }
+    }
+
+    private func routePendingDestination() {
+        guard let rawValue = UserDefaults.standard.string(forKey: "pendingTipEasyDestination"),
+              let destination = TipEasyDestination(rawValue: rawValue)
+        else {
+            return
+        }
+
+        switch destination {
+        case .calculator, .scanner:
+            selectedTab = .calculator
+        case .history:
+            selectedTab = .history
+        case .settings:
+            selectedTab = .settings
+        }
+
+        UserDefaults.standard.removeObject(forKey: "pendingTipEasyDestination")
+    }
+}
+
+private enum AppTab: Hashable {
+    case calculator
+    case history
+    case settings
 }
 
 #Preview {

--- a/SwiftUI-TipEasy/Views/OnboardingView.swift
+++ b/SwiftUI-TipEasy/Views/OnboardingView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @Environment(\.appPalette) private var palette
+    @Binding var hasCompletedOnboarding: Bool
+    @State private var selectedPage = 0
+
+    private let pages = OnboardingPage.allCases
+
+    var body: some View {
+        VStack(spacing: .spacingLarge) {
+            HStack {
+                Text("Tip Easy")
+                    .font(.headline)
+                Spacer()
+                Button("Skip") {
+                    completeOnboarding()
+                }
+                .buttonStyle(.glass)
+            }
+            .padding(.horizontal)
+            .padding(.top, 18)
+
+            TabView(selection: $selectedPage) {
+                ForEach(Array(pages.enumerated()), id: \.element.id) { index, page in
+                    OnboardingPageView(page: page)
+                        .tag(index)
+                        .padding(.horizontal)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+
+            Button {
+                advance()
+            } label: {
+                Label(selectedPage == pages.count - 1 ? "Start Calculating" : "Next", systemImage: selectedPage == pages.count - 1 ? "checkmark" : "arrow.right")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.glassProminent)
+            .padding(.horizontal)
+            .padding(.bottom, 24)
+        }
+        .background(
+            LinearGradient(
+                colors: [
+                    palette.backgroundTop,
+                    palette.backgroundMid,
+                    palette.backgroundBottom
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+        )
+        .tint(palette.accent)
+    }
+
+    private func advance() {
+        guard selectedPage < pages.count - 1 else {
+            completeOnboarding()
+            return
+        }
+
+        withAnimation(.snappy) {
+            selectedPage += 1
+        }
+    }
+
+    private func completeOnboarding() {
+        hasCompletedOnboarding = true
+    }
+}
+
+private struct OnboardingPageView: View {
+    @Environment(\.appPalette) private var palette
+    let page: OnboardingPage
+
+    var body: some View {
+        VStack(spacing: 26) {
+            Spacer()
+
+            Image(systemName: page.iconName)
+                .font(.system(size: 62, weight: .semibold))
+                .foregroundStyle(palette.accent)
+                .frame(width: 118, height: 118)
+                .background(palette.selectedTile, in: Circle())
+                .glassEffect(.regular.tint(palette.accent.opacity(0.12)), in: .circle)
+
+            VStack(spacing: 10) {
+                Text(page.title)
+                    .font(.largeTitle.weight(.bold))
+                    .fontDesign(.rounded)
+                    .multilineTextAlignment(.center)
+
+                Text(page.message)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(3)
+            }
+            .padding(.horizontal, 8)
+
+            pagePreview
+
+            Spacer()
+        }
+    }
+
+    private var pagePreview: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(page.previewItems, id: \.self) { item in
+                HStack(spacing: 10) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(palette.secondaryAccent)
+                    Text(item)
+                        .font(.subheadline.weight(.medium))
+                    Spacer()
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(palette.card, in: RoundedRectangle(cornerRadius: .cornerRadiusLarge))
+        .glassEffect(.regular.tint(palette.glassTint), in: .rect(cornerRadius: .cornerRadiusLarge))
+    }
+}
+
+private enum OnboardingPage: String, CaseIterable, Identifiable {
+    case calculate
+    case scan
+    case save
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .calculate:
+            "percent"
+        case .scan:
+            "camera.viewfinder"
+        case .save:
+            "tray.and.arrow.down"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .calculate:
+            "Compare Tips Fast"
+        case .scan:
+            "Scan a Receipt"
+        case .save:
+            "Save the Visit"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .calculate:
+            "Enter the bill total and choose from quick suggestions like 15%, 18%, 20%, and 25%."
+        case .scan:
+            "Use the camera button to read a receipt total and see tip suggestions over the scanner."
+        case .save:
+            "Add the place name, save the result, and review your local history by month."
+        }
+    }
+
+    var previewItems: [String] {
+        switch self {
+        case .calculate:
+            ["Bill total", "Tip options", "Final total"]
+        case .scan:
+            ["Receipt total", "Suggested tips", "Use detected amount"]
+        case .save:
+            ["Restaurant name", "Monthly history", "Local totals"]
+        }
+    }
+}
+
+#Preview {
+    OnboardingView(hasCompletedOnboarding: .constant(false))
+        .environment(\.appTheme, .harvest)
+}

--- a/SwiftUI-TipEasy/Views/ReceiptScannerSheet.swift
+++ b/SwiftUI-TipEasy/Views/ReceiptScannerSheet.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+import VisionKit
+
+struct ReceiptScannerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appPalette) private var palette
+    @State private var recognizedText = ""
+    @State private var scanResult = ReceiptScanResult.empty
+    @State private var isAnalyzing = false
+
+    let onDetectedResult: (ReceiptScanResult) -> Void
+    private let currencyCode = Locale.current.currency?.identifier ?? "USD"
+    private let commonTips = [0.15, 0.18, 0.20, 0.25]
+
+    private var detectedTotal: Double? {
+        scanResult.total
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottom) {
+                if DataScannerViewController.isSupported, DataScannerViewController.isAvailable {
+                    ReceiptDataScannerView(recognizedText: $recognizedText)
+                        .ignoresSafeArea()
+                } else {
+                    ContentUnavailableView(
+                        "Receipt Scanner Unavailable",
+                        systemImage: "camera.viewfinder",
+                        description: Text("Use a device with camera text recognition, or enter the bill manually.")
+                    )
+                }
+
+                scannerOverlay
+            }
+            .navigationTitle("Scan Receipt")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+            .task(id: recognizedText) {
+                await analyzeRecognizedText()
+            }
+        }
+    }
+
+    private var scannerOverlay: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Detected total")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(alignment: .firstTextBaseline) {
+                Text(detectedTotal ?? 0, format: .currency(code: currencyCode))
+                    .font(.largeTitle.weight(.bold))
+                    .fontDesign(.rounded)
+                    .contentTransition(.numericText())
+                Spacer()
+                Button {
+                    if detectedTotal != nil {
+                        onDetectedResult(scanResult)
+                    }
+                } label: {
+                    Label("Use", systemImage: "checkmark")
+                }
+                .buttonStyle(.glassProminent)
+                .disabled(detectedTotal == nil)
+            }
+
+            if !scanResult.merchantName.isEmpty {
+                Label(scanResult.merchantName, systemImage: "fork.knife")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            if let detectedTotal {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 92), spacing: 8)], spacing: 8) {
+                    ForEach(commonTips, id: \.self) { tip in
+                        ScannerTipTile(
+                            percentage: tip,
+                            bill: detectedTotal,
+                            currencyCode: currencyCode
+                        )
+                    }
+                }
+            }
+
+            Text(isAnalyzing ? "Reading receipt details..." : scanResult.usedAppleIntelligence ? "Apple Intelligence refined the receipt details on device." : "Point the camera at the receipt total. Tip Easy also looks for service charges and merchant names.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(palette.card, in: RoundedRectangle(cornerRadius: 22))
+        .glassEffect(.regular.tint(palette.glassTint), in: .rect(cornerRadius: 22))
+        .padding()
+    }
+
+    private func analyzeRecognizedText() async {
+        guard !recognizedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        isAnalyzing = true
+        let result = await ReceiptIntelligenceService.analyzeReceiptText(recognizedText)
+        await MainActor.run {
+            scanResult = result
+            isAnalyzing = false
+        }
+    }
+}
+
+private struct ScannerTipTile: View {
+    @Environment(\.appPalette) private var palette
+
+    let percentage: Double
+    let bill: Double
+    let currencyCode: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("\(Int(percentage * 100))%")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.secondary)
+            Text(bill * percentage, format: .currency(code: currencyCode))
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(palette.tile, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct ReceiptDataScannerView: UIViewControllerRepresentable {
+    @Binding var recognizedText: String
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let scanner = DataScannerViewController(
+            recognizedDataTypes: [.text()],
+            qualityLevel: .balanced,
+            recognizesMultipleItems: true,
+            isHighFrameRateTrackingEnabled: false,
+            isPinchToZoomEnabled: true,
+            isGuidanceEnabled: true,
+            isHighlightingEnabled: true
+        )
+        scanner.delegate = context.coordinator
+        return scanner
+    }
+
+    func updateUIViewController(_ scanner: DataScannerViewController, context: Context) {
+        guard !scanner.isScanning else { return }
+        try? scanner.startScanning()
+    }
+
+    static func dismantleUIViewController(_ scanner: DataScannerViewController, coordinator: Coordinator) {
+        scanner.stopScanning()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(recognizedText: $recognizedText)
+    }
+
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        @Binding private var recognizedText: String
+
+        init(recognizedText: Binding<String>) {
+            _recognizedText = recognizedText
+        }
+
+        func dataScanner(_ dataScanner: DataScannerViewController, didAdd addedItems: [RecognizedItem], allItems: [RecognizedItem]) {
+            updateDetectedTotal(from: allItems)
+        }
+
+        func dataScanner(_ dataScanner: DataScannerViewController, didUpdate updatedItems: [RecognizedItem], allItems: [RecognizedItem]) {
+            updateDetectedTotal(from: allItems)
+        }
+
+        private func updateDetectedTotal(from items: [RecognizedItem]) {
+            let text = items.compactMap { item -> String? in
+                if case let .text(recognizedText) = item {
+                    return recognizedText.transcript
+                }
+                return nil
+            }
+            .joined(separator: "\n")
+
+            Task { @MainActor in
+                recognizedText = text
+            }
+        }
+    }
+}

--- a/SwiftUI-TipEasy/Views/TipCalculatorView.swift
+++ b/SwiftUI-TipEasy/Views/TipCalculatorView.swift
@@ -1,16 +1,15 @@
-import Combine
 import SwiftData
 import SwiftUI
 
 enum TipInputMode {
-    case percentage, dollar
+    case percentage
+    case dollar
 }
 
-// MARK: - Design System Constants
 extension CGFloat {
     static let cornerRadiusSmall: CGFloat = 8
-    static let cornerRadiusMedium: CGFloat = 10
-    static let cornerRadiusLarge: CGFloat = 12
+    static let cornerRadiusMedium: CGFloat = 12
+    static let cornerRadiusLarge: CGFloat = 20
     static let minimumTouchTarget: CGFloat = 44
     static let spacingSmall: CGFloat = 8
     static let spacingMedium: CGFloat = 12
@@ -18,301 +17,487 @@ extension CGFloat {
 }
 
 struct TipCalculatorView: View {
-    // MARK: - Properties
-    
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.appPalette) private var palette
+    @AppStorage("pendingOpenScanner") private var pendingOpenScanner = false
+    @Query(sort: \TipPreset.percentage) private var tipPresets: [TipPreset]
+    @Query(sort: \TipTransaction.date, order: .reverse) private var transactions: [TipTransaction]
+
+    @State private var restaurantName: String = ""
     @State private var billAmount: String = ""
-    
-    // Remove separate tip amount and percentage fields.
-    // Use one custom tip field:
     @State private var customTipValue: String = ""
     @State private var tipInputMode: TipInputMode = .percentage
-    
-    @State private var selectedTipPercentage: Double = 0.15
-    @State private var tipPercentage: Double = 0.15
-    @State private var shouldClearCustomFields: Bool = true
-    @State private var isEditingCustomTip: Bool = false
-    @State private var tipWorkItem: DispatchWorkItem?
-    
-    // Instead of using AppStorage, we query the TipPreset model.
-    @Query(sort: \TipPreset.percentage) private var tipPresets: [TipPreset]
-    
-    // Default presets (if no models exist).
-    private let defaultPresets: [Double] = [0.10, 0.12, 0.15, 0.18, 0.20, 0.22, 0.25]
-    private let debounceInterval: TimeInterval = 0.8
-    
-    // MARK: - Computed Properties
+    @State private var selectedTipPercentage: Double = 0.18
+    @State private var showingScanner = false
+    @State private var showingSavedConfirmation = false
+    @State private var receiptScanResult: ReceiptScanResult?
+
+    private let defaultPresets: [Double] = [0.15, 0.18, 0.20, 0.25]
+    private let currencyCode = Locale.current.currency?.identifier ?? "USD"
 
     private var bill: Double {
-        Double(billAmount) ?? 0
+        parseAmount(billAmount)
     }
-    
-    // When in percentage mode, customTipValue is treated as percentage (e.g., 15 means 15%)
-    // When in dollar mode, customTipValue is treated as tip dollars.
+
     private var computedTipPercentage: Double {
-        if bill > 0, let entered = Double(customTipValue), !customTipValue.isEmpty {
-            switch tipInputMode {
-            case .percentage:
-                return entered / 100
-            case .dollar:
-                return entered / bill
-            }
+        guard bill > 0, let customValue = Double(customTipValue), !customTipValue.isEmpty else {
+            return selectedTipPercentage
         }
-        return tipPercentage
+
+        switch tipInputMode {
+        case .percentage:
+            return customValue / 100
+        case .dollar:
+            return customValue / bill
+        }
     }
-    
+
     private var computedTipAmount: Double {
         switch tipInputMode {
         case .percentage:
             return bill * computedTipPercentage
         case .dollar:
-            if let entered = Double(customTipValue) {
-                return entered
+            if let customValue = Double(customTipValue), !customTipValue.isEmpty {
+                return customValue
             }
-            return bill * tipPercentage
+            return bill * selectedTipPercentage
         }
     }
-    
+
     private var totalAmount: Double {
         bill + computedTipAmount
     }
-    
-    // Calculate preset percentages based on TipPreset models.
-    // If no presets exist in the model container, use defaultPresets.
+
     private var presetPercentageValues: [Double] {
-        if tipPresets.isEmpty {
-            return defaultPresets
-        } else {
-            return tipPresets.map { $0.percentage }
-        }
+        tipPresets.isEmpty ? defaultPresets : tipPresets.map(\.percentage)
     }
-    
-    // Create rows from the presetPercentageValues.
-    private var presetButtonRows: some View {
-        let presets = presetPercentageValues
-        let count = presets.count
-        let splitIndex = (count + 1) / 2
-        let firstRow = count < 4 ? Array(presets) : Array(presets.prefix(splitIndex))
-        let secondRow = count < 4 ? [] : Array(presets.suffix(from: splitIndex))
-        return VStack(spacing: 10) {
-            HStack(spacing: 10) {
-                ForEach(firstRow, id: \.self) { percentage in
-                    createPresetButton(for: percentage)
-                }
+
+    private var tipExplanation: TipInsight? {
+        TipIntelligenceService.explanation(
+            bill: bill,
+            tipPercentage: computedTipPercentage,
+            tipAmount: computedTipAmount,
+            scanResult: receiptScanResult
+        )
+    }
+
+    private var anomalyInsights: [TipInsight] {
+        TipIntelligenceService.anomalies(
+            bill: bill,
+            tipPercentage: computedTipPercentage,
+            restaurantName: restaurantName,
+            scanResult: receiptScanResult,
+            transactions: transactions
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: .spacingLarge) {
+                headerView
+                billCard
+                suggestionsCard
+                intelligenceCard
+                customTipCard
+                totalCard
+                actionsCard
             }
-            if !secondRow.isEmpty {
-                HStack(spacing: 10) {
-                    ForEach(secondRow, id: \.self) { percentage in
-                        createPresetButton(for: percentage)
-                    }
+            .padding(.horizontal)
+            .padding(.top, 12)
+            .padding(.bottom, 84)
+        }
+        .background(backgroundGradient)
+        .navigationTitle("Tip Easy")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingScanner = true
+                } label: {
+                    Image(systemName: "camera.viewfinder")
+                        .symbolRenderingMode(.hierarchical)
                 }
+                .glassEffect(.regular.interactive())
+                .accessibilityLabel("Scan receipt")
+            }
+        }
+        .tint(palette.accent)
+        .safeAreaInset(edge: .bottom) {
+            AdBannerView(adUnitID: "ca-app-pub-3911596373332918/3954995797")
+                .frame(height: 50)
+                .background(.bar)
+        }
+        .sheet(isPresented: $showingScanner) {
+            ReceiptScannerSheet { result in
+                if let total = result.total {
+                    billAmount = total.formatted(.number.precision(.fractionLength(2)))
+                }
+
+                if !result.merchantName.isEmpty {
+                    restaurantName = result.merchantName
+                }
+
+                receiptScanResult = result
+                showingScanner = false
+            }
+        }
+        .sensoryFeedback(.success, trigger: showingSavedConfirmation)
+        .alert("Saved to History", isPresented: $showingSavedConfirmation) {
+            Button("Done", role: .cancel) {}
+        } message: {
+            Text("This tip calculation is now stored locally on this device.")
+        }
+        .onAppear {
+            if pendingOpenScanner {
+                pendingOpenScanner = false
+                showingScanner = true
             }
         }
     }
-    
-    // MARK: - View Components
-    
-    private var billInputField: some View {
-        HStack(spacing: .spacingMedium) {
-            Image(systemName: "dollarsign.circle.fill")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-                .symbolRenderingMode(.hierarchical)
-            TextField("Enter bill amount", text: $billAmount)
-                .keyboardType(.decimalPad)
-                .textFieldStyle(RoundedTextFieldStyle())
-        }
-    }
-    
-    private var tipPercentageSlider: some View {
-        VStack {
-            Slider(value: $selectedTipPercentage, in: 0 ... 0.50, step: 0.01)
-                .tint(.accentColor)
-                .onChange(of: selectedTipPercentage) { _, newValue in
-                    updateTipFromSlider(newValue)
-                }
-            Text("Tip Percentage: \(Int(selectedTipPercentage * 100))%")
+
+    private var headerView: some View {
+        VStack(alignment: .leading, spacing: .spacingSmall) {
+            Text("Settle the bill without the clutter.")
+                .font(.title2.weight(.semibold))
+            Text("Enter the total, compare common tip options, then save the visit when it matters.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
-    
-    // A single custom tip input field with a toggle to switch between percentage and dollar mode.
-    private var customTipInputField: some View {
-        VStack(alignment: .leading, spacing: .spacingSmall) {
-            HStack(spacing: .spacingSmall) {
-                TextField(tipInputMode == .percentage ?
-                    "Enter tip percentage" : "Enter tip amount", text: $customTipValue, onEditingChanged: handleCustomTipEditing)
+
+    private var billCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Bill", systemImage: "receipt")
+                .font(.headline)
+
+            TextField("Restaurant or place", text: $restaurantName)
+                .textInputAutocapitalization(.words)
+                .textFieldStyle(GlassTextFieldStyle(palette: palette))
+
+            HStack(spacing: .spacingMedium) {
+                Text(Locale.current.currencySymbol ?? "$")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28)
+
+                TextField("0.00", text: $billAmount)
                     .keyboardType(.decimalPad)
-                    .textFieldStyle(RoundedTextFieldStyle())
-            
-                Button(action: {
-                    tipInputMode = .percentage
-                }) {
-                    Image(systemName: "percent")
-                        .frame(minWidth: .minimumTouchTarget, minHeight: .minimumTouchTarget)
-                }
-                .buttonStyle(.bordered)
-                .tint(tipInputMode == .percentage ? .accentColor : .secondary)
-                .accessibilityLabel("Percentage mode")
-                
-                Button(action: {
-                    tipInputMode = .dollar
-                }) {
-                    Image(systemName: "dollarsign")
-                        .frame(minWidth: .minimumTouchTarget, minHeight: .minimumTouchTarget)
-                }
-                .buttonStyle(.bordered)
-                .tint(tipInputMode == .dollar ? .accentColor : .secondary)
-                .accessibilityLabel("Dollar mode")
+                    .font(.system(.largeTitle, design: .rounded).weight(.bold))
+                    .textFieldStyle(.plain)
+                    .submitLabel(.done)
+                    .accessibilityLabel("Bill amount")
+            }
+            .padding()
+            .frame(minHeight: 76)
+            .background(palette.field, in: RoundedRectangle(cornerRadius: .cornerRadiusLarge))
+        }
+        .glassCard(palette: palette)
+    }
+
+    private var intelligenceCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Smart Check", systemImage: "brain")
+                .font(.headline)
+
+            if let tipExplanation {
+                InsightRow(insight: tipExplanation)
+            }
+
+            ForEach(anomalyInsights) { insight in
+                InsightRow(insight: insight)
+            }
+
+            if tipExplanation == nil, anomalyInsights.isEmpty {
+                Text("Enter a bill or scan a receipt to see context, duplicate checks, and receipt warnings.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let receiptScanResult, receiptScanResult.usedAppleIntelligence {
+                Label("Receipt details refined with Apple Intelligence on device.", systemImage: "apple.intelligence")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
             }
         }
+        .glassCard(palette: palette, tint: anomalyInsights.isEmpty ? palette.card : palette.highlight.opacity(0.24))
     }
-    
-    private var summaryView: some View {
-        VStack(spacing: .spacingMedium) {
-            Text("Bill: $\(bill, specifier: "%.2f")")
-            Text("Tip: $\(computedTipAmount, specifier: "%.2f") (\(Int(computedTipPercentage * 100))%)")
-            Divider()
-            HStack(alignment: .center) {
-                Text("Total: $\(totalAmount, specifier: "%.2f")")
-                    .font(.title2)
-                    .fontWeight(.semibold)
+
+    private var suggestionsCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            HStack {
+                Label("Tip Suggestions", systemImage: "sparkles")
+                    .font(.headline)
+                Spacer()
+                Text("\(Int(computedTipPercentage * 100))% selected")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 144), spacing: 10)], spacing: 10) {
+                ForEach(presetPercentageValues, id: \.self) { percentage in
+                    Button {
+                        selectPreset(percentage)
+                    } label: {
+                        TipSuggestionTile(
+                            percentage: percentage,
+                            bill: bill,
+                            currencyCode: currencyCode,
+                            isSelected: abs(percentage - computedTipPercentage) < 0.001
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
-        .font(.body)
-        .fontWeight(.medium)
-        .padding()
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: .cornerRadiusLarge))
-        .animation(.default, value: totalAmount)
+        .glassCard(palette: palette)
     }
-    
-    // MARK: - Body
-    
-    var body: some View {
-        VStack(spacing: .spacingLarge) {
-            Text("Tip Easy")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-                .fontDesign(.rounded)
-            billInputField
-            tipPercentageSlider
-            presetButtonRows
-            customTipInputField
-            summaryView
-            Spacer()
-            AdBannerView(adUnitID: "ca-app-pub-3911596373332918/3954995797")
-                .frame(height: 50)
+
+    private var customTipCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Custom Tip", systemImage: "slider.horizontal.below.rectangle")
+                .font(.headline)
+
+            Picker("Tip input mode", selection: $tipInputMode) {
+                Label("Percent", systemImage: "percent").tag(TipInputMode.percentage)
+                Label("Amount", systemImage: "dollarsign").tag(TipInputMode.dollar)
+            }
+            .pickerStyle(.segmented)
+
+            TextField(tipInputMode == .percentage ? "Custom percentage" : "Custom tip amount", text: $customTipValue)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(GlassTextFieldStyle(palette: palette))
+                .onChange(of: customTipValue) { _, newValue in
+                    if !newValue.isEmpty {
+                        synchronizeCustomTip()
+                    }
+                }
         }
-        .padding()
+        .glassCard(palette: palette)
     }
-    
-    // MARK: - Helper Methods
-    
-    private func createPresetButton(for percentage: Double) -> some View {
-        Button(action: {
-            shouldClearCustomFields = true
-            updateTipFromPreset(percentage)
-        }) {
-            Text("\(Int(percentage * 100))%")
-                .padding()
-                .frame(minWidth: .minimumTouchTarget, minHeight: .minimumTouchTarget)
-                .background((abs(percentage - tipPercentage) < 0.001)
-                    ? Color.accentColor
-                    : Color.accentColor.opacity(0.8))
-                .foregroundStyle(.white)
-                .clipShape(RoundedRectangle(cornerRadius: .cornerRadiusMedium))
+
+    private var totalCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Today", systemImage: "checkmark.circle")
+                .font(.headline)
+
+            HStack {
+                AmountColumn(title: "Tip", amount: computedTipAmount, currencyCode: currencyCode)
+                Divider()
+                AmountColumn(title: "Total", amount: totalAmount, currencyCode: currencyCode, isPrimary: true)
+            }
+            .frame(minHeight: 88)
+
+            HStack {
+                Text("Bill")
+                Spacer()
+                Text(bill, format: .currency(code: currencyCode))
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
         }
-        .buttonStyle(.plain)
+        .glassCard(palette: palette, tint: palette.secondaryAccent.opacity(0.22))
+        .animation(.snappy, value: totalAmount)
     }
-    
-    private func updateTipFromSlider(_ newValue: Double) {
-        withAnimation {
-            tipPercentage = newValue
-            selectedTipPercentage = newValue
-            if shouldClearCustomFields { clearCustomTipField() }
-            cancelTipWorkItem()
+
+    private var actionsCard: some View {
+        HStack(spacing: .spacingMedium) {
+            Button {
+                resetCalculator()
+            } label: {
+                Label("Clear", systemImage: "xmark.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.glass)
+
+            Button {
+                saveTransaction()
+            } label: {
+                Label("Save", systemImage: "tray.and.arrow.down")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.glassProminent)
+            .disabled(bill <= 0)
         }
     }
-    
-    private func updateTipFromPreset(_ percentage: Double) {
-        // Provide haptic feedback
+
+    private var backgroundGradient: some View {
+        LinearGradient(
+            colors: [
+                palette.backgroundTop,
+                palette.backgroundMid,
+                palette.backgroundBottom
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .ignoresSafeArea()
+    }
+
+    private func selectPreset(_ percentage: Double) {
         let impact = UIImpactFeedbackGenerator(style: .light)
         impact.impactOccurred()
-        
-        withAnimation {
-            tipPercentage = percentage
+
+        withAnimation(.snappy) {
             selectedTipPercentage = percentage
-            if shouldClearCustomFields { clearCustomTipField() }
-            cancelTipWorkItem()
+            customTipValue = ""
+            tipInputMode = .percentage
         }
     }
-    
-    private func clearCustomTipField() {
-        customTipValue = ""
-    }
-    
-    private func cancelTipWorkItem() {
-        tipWorkItem?.cancel()
-    }
-    
-    private func debouncedCustomTipUpdate(oldValue: String, newValue: String) {
-        cancelTipWorkItem()
-        let workItem = DispatchWorkItem {
-            updateCustomTip()
-        }
-        tipWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + debounceInterval, execute: workItem)
-    }
-    
-    private func handleCustomTipEditing(_ editing: Bool) {
-        isEditingCustomTip = editing
-        if !editing {
-            updateCustomTip()
+
+    private func synchronizeCustomTip() {
+        guard bill > 0 else { return }
+        switch tipInputMode {
+        case .percentage:
+            selectedTipPercentage = (Double(customTipValue) ?? 0) / 100
+        case .dollar:
+            selectedTipPercentage = (Double(customTipValue) ?? 0) / bill
         }
     }
-    
-    private func updateCustomTip() {
-        guard !customTipValue.trimmingCharacters(in: .whitespaces).isEmpty, bill > 0 else { return }
-        withAnimation {
-            if tipInputMode == .percentage {
-                let entered = Double(customTipValue) ?? 0
-                tipPercentage = entered / 100
-            } else {
-                let entered = Double(customTipValue) ?? 0
-                tipPercentage = entered / bill
-            }
-            selectedTipPercentage = tipPercentage
-            shouldClearCustomFields = false
+
+    private func saveTransaction() {
+        guard bill > 0 else { return }
+
+        let transaction = TipTransaction(
+            restaurantName: restaurantName.trimmingCharacters(in: .whitespacesAndNewlines),
+            billAmount: bill,
+            tipPercentage: computedTipPercentage,
+            tipAmount: computedTipAmount,
+            totalAmount: totalAmount
+        )
+        modelContext.insert(transaction)
+        showingSavedConfirmation = true
+    }
+
+    private func resetCalculator() {
+        withAnimation(.snappy) {
+            restaurantName = ""
+            billAmount = ""
+            customTipValue = ""
+            tipInputMode = .percentage
+            selectedTipPercentage = presetPercentageValues.first ?? 0.18
+            receiptScanResult = nil
         }
+    }
+
+    private func parseAmount(_ text: String) -> Double {
+        let allowed = CharacterSet(charactersIn: "0123456789.")
+        let filtered = String(text.unicodeScalars.filter { allowed.contains($0) })
+        return Double(filtered) ?? 0
     }
 }
 
-// MARK: - Custom Styles
+private struct InsightRow: View {
+    @Environment(\.appPalette) private var palette
+    let insight: TipInsight
 
-struct RoundedTextFieldStyle: TextFieldStyle {
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: insight.kind == .warning ? "exclamationmark.triangle.fill" : "info.circle.fill")
+                .foregroundStyle(insight.kind == .warning ? palette.highlight : palette.secondaryAccent)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(insight.title)
+                    .font(.subheadline.weight(.semibold))
+                Text(insight.message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct TipSuggestionTile: View {
+    @Environment(\.appPalette) private var palette
+
+    let percentage: Double
+    let bill: Double
+    let currencyCode: String
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("\(Int(percentage * 100))%")
+                    .font(.title3.weight(.bold))
+                Spacer()
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? palette.accent : palette.secondaryAccent.opacity(0.72))
+            }
+
+            Text(bill * percentage, format: .currency(code: currencyCode))
+                .font(.headline)
+                .contentTransition(.numericText())
+
+            Text("Total \((bill + bill * percentage).formatted(.currency(code: currencyCode)))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, minHeight: 116, alignment: .leading)
+        .background(isSelected ? palette.selectedTile : palette.tile, in: RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(isSelected ? palette.accent.opacity(0.50) : palette.highlight.opacity(0.20), lineWidth: 1)
+        }
+        .glassEffect(isSelected ? .regular.tint(palette.accent.opacity(0.14)).interactive() : .regular.tint(palette.glassTint).interactive(), in: .rect(cornerRadius: 16))
+    }
+}
+
+private struct AmountColumn: View {
+    let title: String
+    let amount: Double
+    let currencyCode: String
+    var isPrimary = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(amount, format: .currency(code: currencyCode))
+                .font(isPrimary ? .title.weight(.bold) : .title2.weight(.semibold))
+                .fontDesign(.rounded)
+                .contentTransition(.numericText())
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct GlassTextFieldStyle: TextFieldStyle {
+    let palette: ThemePalette
+
     func _body(configuration: TextField<Self._Label>) -> some View {
         configuration
-            .keyboardType(.decimalPad)
-            .submitLabel(.done)
             .padding()
             .frame(minHeight: .minimumTouchTarget)
-            .background(.regularMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: .cornerRadiusMedium))
-            .overlay(
+            .background(palette.field, in: RoundedRectangle(cornerRadius: .cornerRadiusMedium))
+            .overlay {
                 RoundedRectangle(cornerRadius: .cornerRadiusMedium)
-                    .strokeBorder(Color.secondary.opacity(0.2), lineWidth: 1)
-            )
+                    .strokeBorder(palette.stroke, lineWidth: 1)
+            }
     }
 }
 
-struct TipCalculatorView_Previews: PreviewProvider {
-    static var previews: some View {
-        Group {
-            TipCalculatorView()
-                .preferredColorScheme(.light)
-            TipCalculatorView()
-                .preferredColorScheme(.dark)
-        }
+private extension View {
+    func glassCard(palette: ThemePalette, tint: Color? = nil) -> some View {
+        self
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(tint ?? palette.card, in: RoundedRectangle(cornerRadius: .cornerRadiusLarge))
+            .glassEffect(.regular.tint(palette.glassTint), in: .rect(cornerRadius: .cornerRadiusLarge))
     }
+}
+
+#Preview {
+    NavigationStack {
+        TipCalculatorView()
+    }
+    .modelContainer(for: [TipPreset.self, TipTransaction.self], inMemory: true)
 }

--- a/SwiftUI-TipEasy/Views/TipHistoryView.swift
+++ b/SwiftUI-TipEasy/Views/TipHistoryView.swift
@@ -1,0 +1,228 @@
+import SwiftData
+import SwiftUI
+
+struct TipHistoryView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.appPalette) private var palette
+    @Query(sort: \TipTransaction.date, order: .reverse) private var transactions: [TipTransaction]
+    @State private var searchText = ""
+
+    private let currencyCode = Locale.current.currency?.identifier ?? "USD"
+
+    private var visibleTransactions: [TipTransaction] {
+        HistorySearchService.filter(transactions, query: searchText)
+    }
+
+    private var totalSpent: Double {
+        visibleTransactions.reduce(0) { $0 + $1.totalAmount }
+    }
+
+    private var totalTips: Double {
+        visibleTransactions.reduce(0) { $0 + $1.tipAmount }
+    }
+
+    private var ytdTips: Double {
+        visibleTransactions
+            .filter { Calendar.current.isDate($0.date, equalTo: .now, toGranularity: .year) }
+            .reduce(0) { $0 + $1.tipAmount }
+    }
+
+    private var monthlyGroups: [(month: Date, items: [TipTransaction])] {
+        let grouped = Dictionary(grouping: visibleTransactions) { transaction in
+            Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: transaction.date)) ?? transaction.date
+        }
+        return grouped
+            .map { (month: $0.key, items: $0.value.sorted { $0.date > $1.date }) }
+            .sorted { $0.month > $1.month }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: .spacingLarge) {
+                summaryCards
+                if let summary = TipIntelligenceService.summary(for: visibleTransactions, currencyCode: currencyCode) {
+                    MonthlySummaryCard(summary: summary)
+                }
+
+                if visibleTransactions.isEmpty {
+                    ContentUnavailableView(
+                        searchText.isEmpty ? "No Saved Tips" : "No Matches",
+                        systemImage: searchText.isEmpty ? "tray" : "magnifyingglass",
+                        description: Text(searchText.isEmpty ? "Saved calculations will appear here by month." : "Try a query like this month, over 20%, or a restaurant name.")
+                    )
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 60)
+                } else {
+                    historyList
+                }
+            }
+            .padding()
+        }
+        .background(
+            LinearGradient(
+                colors: [
+                    palette.backgroundTop,
+                    palette.backgroundBottom
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
+        .navigationTitle("History")
+        .searchable(text: $searchText, prompt: "Try: this month, over 20%, coffee")
+    }
+
+    private var summaryCards: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Local Totals", systemImage: "chart.bar.xaxis")
+                .font(.headline)
+
+            HStack(spacing: .spacingMedium) {
+                HistoryMetric(title: "Spent", value: totalSpent, currencyCode: currencyCode)
+                HistoryMetric(title: "Tips", value: totalTips, currencyCode: currencyCode)
+                HistoryMetric(title: "YTD", value: ytdTips, currencyCode: currencyCode)
+            }
+        }
+        .historyGlassCard(palette: palette)
+    }
+
+    private var historyList: some View {
+        VStack(alignment: .leading, spacing: .spacingLarge) {
+            ForEach(monthlyGroups, id: \.month) { group in
+                VStack(alignment: .leading, spacing: .spacingMedium) {
+                    Text(group.month, format: .dateTime.month(.wide).year())
+                        .font(.title3.weight(.semibold))
+
+                    VStack(spacing: 10) {
+                        ForEach(group.items) { transaction in
+                            TipHistoryRow(transaction: transaction, currencyCode: currencyCode) {
+                                withAnimation {
+                                    modelContext.delete(transaction)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct MonthlySummaryCard: View {
+    @Environment(\.appPalette) private var palette
+    let summary: HistorySummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label(summary.title, systemImage: "sparkles")
+                .font(.headline)
+
+            Text(summary.message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 10)], spacing: 10) {
+                ForEach(summary.highlights, id: \.self) { highlight in
+                    Text(highlight)
+                        .font(.caption.weight(.semibold))
+                        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .background(palette.tile, in: RoundedRectangle(cornerRadius: 14))
+                }
+            }
+        }
+        .historyGlassCard(palette: palette)
+    }
+}
+
+private struct HistoryMetric: View {
+    @Environment(\.appPalette) private var palette
+
+    let title: String
+    let value: Double
+    let currencyCode: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value, format: .currency(code: currencyCode))
+                .font(.headline.weight(.bold))
+                .fontDesign(.rounded)
+                .lineLimit(1)
+                .minimumScaleFactor(0.65)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(palette.tile, in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+private struct TipHistoryRow: View {
+    @Environment(\.appPalette) private var palette
+
+    let transaction: TipTransaction
+    let currencyCode: String
+    let onDelete: () -> Void
+
+    private var title: String {
+        transaction.restaurantName.isEmpty ? "Saved bill" : transaction.restaurantName
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "fork.knife.circle.fill")
+                .font(.title2)
+                .foregroundStyle(palette.accent)
+                .symbolRenderingMode(.hierarchical)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text(transaction.date, format: .dateTime.weekday(.abbreviated).day().hour().minute())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(transaction.totalAmount, format: .currency(code: currencyCode))
+                    .font(.headline.weight(.semibold))
+                Text("\(Int(transaction.tipPercentage * 100))% tip")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .background(palette.card, in: RoundedRectangle(cornerRadius: 18))
+        .glassEffect(.regular.tint(palette.glassTint).interactive(), in: .rect(cornerRadius: 18))
+        .contextMenu {
+            Button(role: .destructive) {
+                onDelete()
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+}
+
+private extension View {
+    func historyGlassCard(palette: ThemePalette) -> some View {
+        self
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(palette.card, in: RoundedRectangle(cornerRadius: .cornerRadiusLarge))
+            .glassEffect(.regular.tint(palette.glassTint), in: .rect(cornerRadius: .cornerRadiusLarge))
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TipHistoryView()
+    }
+    .modelContainer(for: [TipPreset.self, TipTransaction.self], inMemory: true)
+}

--- a/SwiftUI-TipEasy/Views/TipPresetSettingsView.swift
+++ b/SwiftUI-TipEasy/Views/TipPresetSettingsView.swift
@@ -2,100 +2,314 @@ import SwiftData
 import SwiftUI
 
 struct TipPresetSettingsView: View {
-    // Query the TipPreset models from the container.
-    @Query(sort: \TipPreset.percentage) private var tipPresets: [TipPreset]
-    // Environment modelContext for insert, update, delete.
     @Environment(\.modelContext) private var modelContext
-    // Used to dismiss the view.
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.appPalette) private var palette
+    @AppStorage("selectedAppTheme") private var selectedThemeRawValue = AppTheme.harvest.rawValue
+    @AppStorage("appAppearance") private var appAppearanceRawValue = AppAppearance.system.rawValue
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @Query(sort: \TipPreset.percentage) private var tipPresets: [TipPreset]
 
-    // Sheet state for adding/editing a preset.
-    @State private var showingPresetSheet: Bool = false
-    @State private var presetToEdit: TipPreset? = nil
+    @State private var showingPresetSheet = false
+    @State private var presetToEdit: TipPreset?
+
+    private let defaultPresets: [Double] = [0.15, 0.18, 0.20, 0.25]
+
+    private var selectedTheme: AppTheme {
+        AppTheme(rawValue: selectedThemeRawValue) ?? .harvest
+    }
+
+    private var selectedThemeBinding: Binding<AppTheme> {
+        Binding {
+            selectedTheme
+        } set: { newValue in
+            selectedThemeRawValue = newValue.rawValue
+        }
+    }
+
+    private var appAppearanceBinding: Binding<AppAppearance> {
+        Binding {
+            AppAppearance(rawValue: appAppearanceRawValue) ?? .system
+        } set: { newValue in
+            appAppearanceRawValue = newValue.rawValue
+        }
+    }
 
     var body: some View {
-        Form {
-            Section {
-                ForEach(tipPresets) { preset in
-                    HStack {
-                        Image(systemName: "percent")
-                            .foregroundStyle(.secondary)
-                            .font(.title3)
-
-                        Text("\(Int(preset.percentage * 100))%")
-                            .font(.body)
-                            .fontWeight(.medium)
-
-                        Spacer()
-
-                        Button {
-                            presetToEdit = preset
-                            showingPresetSheet = true
-                        } label: {
-                            Text("Edit")
-                                .font(.body)
-                        }
-                        .buttonStyle(.bordered)
-                        .tint(.accentColor)
-
-                        Button(role: .destructive) {
-                            withAnimation {
-                                modelContext.delete(preset)
-                            }
-                        } label: {
-                            Image(systemName: "trash")
-                                .font(.body)
-                        }
-                        .buttonStyle(.bordered)
-                        .accessibilityLabel("Delete preset")
-                    }
-                    .padding(.vertical, 4)
-                }
-
-                Button {
-                    presetToEdit = nil
-                    showingPresetSheet = true
-                } label: {
-                    Label("Add New Preset", systemImage: "plus.circle.fill")
-                        .font(.body)
-                }
-            } header: {
-                Text("Tip Percentages")
-            } footer: {
-                Text("Tap Edit to modify a preset or Add to create a new one. These percentages will appear as quick options in the calculator.")
+        ScrollView {
+            VStack(alignment: .leading, spacing: .spacingLarge) {
+                appearanceCard
+                themeCard
+                guideCard
+                introCard
+                presetCard
             }
+            .padding()
         }
-        .navigationTitle("Preset Settings")
-        .navigationBarTitleDisplayMode(.large)
+        .background(
+            LinearGradient(
+                colors: [
+                    palette.backgroundTop,
+                    palette.backgroundBottom
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
+        .tint(palette.accent)
+        .navigationTitle("Settings")
         .sheet(isPresented: $showingPresetSheet) {
             AddEditPresetSheet(presetToEdit: presetToEdit, modelContext: modelContext)
         }
     }
+
+    private var appearanceCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Appearance", systemImage: "circle.lefthalf.filled")
+                .font(.headline)
+
+            Picker("Appearance", selection: appAppearanceBinding) {
+                ForEach(AppAppearance.allCases) { appearance in
+                    Label(appearance.title, systemImage: appearance.iconName)
+                        .tag(appearance)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+        .settingsGlassCard(palette: palette)
+    }
+
+    private var themeCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Label("Color Theme", systemImage: "paintpalette")
+                .font(.headline)
+
+            VStack(spacing: 10) {
+                ForEach(AppTheme.allCases) { theme in
+                    Button {
+                        selectedThemeBinding.wrappedValue = theme
+                    } label: {
+                        ThemeChoiceRow(theme: theme, isSelected: selectedTheme == theme)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .settingsGlassCard(palette: palette)
+    }
+
+    private var guideCard: some View {
+        HStack(spacing: .spacingMedium) {
+            Image(systemName: "questionmark.circle")
+                .font(.title2)
+                .foregroundStyle(palette.accent)
+                .frame(width: 42, height: 42)
+                .background(palette.selectedTile, in: Circle())
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Quick Guide")
+                    .font(.headline)
+                Text("Replay the short first-run walkthrough.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button("Replay") {
+                hasCompletedOnboarding = false
+            }
+            .buttonStyle(.glass)
+        }
+        .settingsGlassCard(palette: palette)
+    }
+
+    private var introCard: some View {
+        VStack(alignment: .leading, spacing: .spacingSmall) {
+            Label("Tip Suggestions", systemImage: "slider.horizontal.3")
+                .font(.headline)
+            Text("Customize the percentages shown on the calculator. If no custom presets exist, Tip Easy uses 15%, 18%, 20%, and 25%.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .settingsGlassCard(palette: palette)
+    }
+
+    private var presetCard: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            HStack {
+                Text("Presets")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    presetToEdit = nil
+                    showingPresetSheet = true
+                } label: {
+                    Image(systemName: "plus")
+                        .frame(width: .minimumTouchTarget, height: .minimumTouchTarget)
+                }
+                .buttonStyle(.glassProminent)
+                .accessibilityLabel("Add preset")
+            }
+
+            if tipPresets.isEmpty {
+                defaultPresetPreview
+            } else {
+                ForEach(tipPresets) { preset in
+                    presetRow(preset)
+                }
+            }
+        }
+        .settingsGlassCard(palette: palette)
+    }
+
+    private var defaultPresetPreview: some View {
+        VStack(alignment: .leading, spacing: .spacingMedium) {
+            Text("Default set active")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            HStack {
+                ForEach(defaultPresets, id: \.self) { percentage in
+                    Text("\(Int(percentage * 100))%")
+                        .font(.headline.weight(.semibold))
+                        .frame(maxWidth: .infinity, minHeight: 52)
+                        .background(palette.tile, in: RoundedRectangle(cornerRadius: 14))
+                }
+            }
+        }
+    }
+
+    private func presetRow(_ preset: TipPreset) -> some View {
+        HStack(spacing: .spacingMedium) {
+            Text("\(Int(preset.percentage * 100))%")
+                .font(.title3.weight(.bold))
+                .frame(width: 76, height: 56)
+                .background(palette.selectedTile, in: RoundedRectangle(cornerRadius: 16))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Quick option")
+                    .font(.headline)
+                Text("Shown on the calculator")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                presetToEdit = preset
+                showingPresetSheet = true
+            } label: {
+                Image(systemName: "pencil")
+                    .frame(width: .minimumTouchTarget, height: .minimumTouchTarget)
+            }
+            .buttonStyle(.glass)
+            .accessibilityLabel("Edit \(Int(preset.percentage * 100)) percent preset")
+
+            Button(role: .destructive) {
+                withAnimation {
+                    modelContext.delete(preset)
+                }
+            } label: {
+                Image(systemName: "trash")
+                    .frame(width: .minimumTouchTarget, height: .minimumTouchTarget)
+            }
+            .buttonStyle(.glass)
+            .accessibilityLabel("Delete \(Int(preset.percentage * 100)) percent preset")
+        }
+        .padding()
+        .background(palette.card, in: RoundedRectangle(cornerRadius: 18))
+        .glassEffect(.regular.tint(palette.glassTint), in: .rect(cornerRadius: 18))
+    }
 }
 
-// Sheet view for adding/editing tip preset.
+private struct ThemeChoiceRow: View {
+    let theme: AppTheme
+    let isSelected: Bool
+
+    private var palette: ThemePalette {
+        theme.palette
+    }
+
+    var body: some View {
+        HStack(spacing: .spacingMedium) {
+            Image(systemName: theme.iconName)
+                .font(.title3)
+                .foregroundStyle(palette.accent)
+                .frame(width: 40, height: 40)
+                .background(palette.selectedTile, in: Circle())
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(theme.title)
+                    .font(.headline)
+                Text(theme.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            HStack(spacing: 5) {
+                Circle().fill(palette.accent)
+                Circle().fill(palette.secondaryAccent)
+                Circle().fill(palette.highlight)
+            }
+            .frame(width: 54, height: 18)
+
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(isSelected ? palette.accent : .secondary)
+        }
+        .padding()
+        .background(isSelected ? palette.selectedTile : palette.tile, in: RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .strokeBorder(isSelected ? palette.accent.opacity(0.46) : palette.highlight.opacity(0.18), lineWidth: 1)
+        }
+        .glassEffect(.regular.tint(isSelected ? palette.accent.opacity(0.10) : palette.glassTint).interactive(), in: .rect(cornerRadius: 18))
+    }
+}
+
 struct AddEditPresetSheet: View {
     let presetToEdit: TipPreset?
     var modelContext: ModelContext
-    @Environment(\.dismiss) var dismiss
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appPalette) private var palette
     @State private var percentageText: String
+
+    private var percentageValue: Double? {
+        Double(percentageText.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private var canSave: Bool {
+        guard let percentageValue else { return false }
+        return percentageValue > 0 && percentageValue <= 100
+    }
 
     init(presetToEdit: TipPreset?, modelContext: ModelContext) {
         self.presetToEdit = presetToEdit
         self.modelContext = modelContext
-        // If editing an existing preset, prefill the text field.
         _percentageText = State(initialValue: presetToEdit.map { String(Int($0.percentage * 100)) } ?? "")
     }
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section(header: Text("Tip Preset (in %)")) {
-                    TextField("Enter tip percentage", text: $percentageText)
-                        .keyboardType(.decimalPad)
-                }
+            VStack(alignment: .leading, spacing: .spacingLarge) {
+                TextField("Tip percentage", text: $percentageText)
+                    .keyboardType(.decimalPad)
+                    .font(.title2.weight(.semibold))
+                    .textFieldStyle(GlassTextFieldStyle(palette: palette))
+
+                Text("Enter a whole or decimal percentage from 1 to 100.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
             }
+            .padding()
             .navigationTitle(presetToEdit == nil ? "Add Preset" : "Edit Preset")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
@@ -104,23 +318,41 @@ struct AddEditPresetSheet: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        if let value = Double(percentageText) {
-                            let fraction = value / 100.0
-                            if let preset = presetToEdit {
-                                preset.percentage = fraction
-                            } else {
-                                let newPreset = TipPreset(percentage: fraction)
-                                modelContext.insert(newPreset)
-                            }
-                        }
-                        dismiss()
+                        savePreset()
                     }
+                    .disabled(!canSave)
                 }
             }
         }
     }
+
+    private func savePreset() {
+        guard let percentageValue else { return }
+        let fraction = percentageValue / 100
+
+        if let presetToEdit {
+            presetToEdit.percentage = fraction
+        } else {
+            modelContext.insert(TipPreset(percentage: fraction))
+        }
+
+        dismiss()
+    }
+}
+
+private extension View {
+    func settingsGlassCard(palette: ThemePalette) -> some View {
+        self
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(palette.card, in: RoundedRectangle(cornerRadius: .cornerRadiusLarge))
+            .glassEffect(.regular.tint(palette.glassTint), in: .rect(cornerRadius: .cornerRadiusLarge))
+    }
 }
 
 #Preview {
-    TipPresetSettingsView()
+    NavigationStack {
+        TipPresetSettingsView()
+    }
+    .modelContainer(for: [TipPreset.self, TipTransaction.self], inMemory: true)
 }


### PR DESCRIPTION
## Summary

- Modernizes Tip Easy with a Liquid Glass tabbed UI, three selectable color themes, first-run onboarding, and dedicated calculator/history/settings surfaces.
- Adds local SwiftData tip history with monthly grouping, local totals, natural-language-style filtering, and summary cards.
- Adds receipt scanning with VisionKit, Apple Intelligence receipt refinement via FoundationModels when available, deterministic parsing fallback, smart restaurant prefill, service-charge warnings, duplicate/anomaly checks, and tip context.
- Adds App Intents / Shortcuts for calculating a tip, saving a tip, opening the scanner, and opening history.

## Validation

- Built, installed, and launched successfully on iPhone 17 Pro simulator through XcodeBuildMCP.
- Final build completed with no warnings or errors.

## Notes

- Receipt camera scanning needs a real camera-capable device for full end-to-end validation.
- Apple Intelligence receipt refinement only runs when SystemLanguageModel.default is available; unsupported devices fall back to the local parser.
